### PR TITLE
Add possibility to pass key and salt in base 64 format

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ import { NativeModules } from 'react-native'
 
 const { RNScrypt } = NativeModules
 
+export async function scryptB64 (passwd, salt, N=16384, r=8, p=1, dkLen=64) {
+  return RNScrypt.scrypt_b64(passwd, salt, N, r, p, dkLen)
+}
+
 export default async function scrypt (passwd, salt, N=16384, r=8, p=1, dkLen=64) {
   return RNScrypt.scrypt(passwd, salt, N, r, p, dkLen)
 }


### PR DESCRIPTION
It's really inconvenient to prepare uint8arrays to use with this library now. We were using base64 format in our ios native module, but since we launching android the crossplatform library is needed, so I added support of base 64.