### PR TITLE
add tex0l in the contributors & bump version to 1.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,14 @@
 Changelog
 =========
 
-UNRELEASED - 2020-10-04
+1.2.0 - 2020-10-23
 ------------------
 - Unified native I/O to hex strings ;
+  [tex0l]
 - Added other encoding methods : 'legacy' which behaves like v1.1.2, 'hex', 'base64' and 'buffer'
+  [tex0l]
 - Update example with tests for a range of test vectors
+  [tex0l]
 
 1.1.2 - 2019-12-20
 ------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-scrypt",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-scrypt",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Native scrypt for React Native",
   "main": "index.js",
   "types": "index.d.ts",
@@ -16,6 +16,11 @@
     {
       "name": "Demetris Manikas",
       "email": "demetris.manikas@gmail.com"
+    },
+    {
+      "name": "Timothée Rebours",
+      "email": "tim@seald.io",
+      "url": "https://github.com/tex0l"
     }
   ],
   "keywords": [


### PR DESCRIPTION
Following up on https://github.com/Crypho/react-native-scrypt/pull/22#issuecomment-715068333